### PR TITLE
feat: introduce ESKitIconElement web component and integrate icons ac…

### DIFF
--- a/API.md
+++ b/API.md
@@ -18,7 +18,7 @@ const System = globalThis.System;
 await System.loadApp("apps/myapp/");         // アプリを起動 → UUID を返す
 System.closeApp(uuid);                        // アプリを終了
 System.getApp(uuid);                          // アプリインスタンスを取得
-System.listProcesses();                       // [{uuid, name, state}, ...]
+System.listProcesses();                       // [{uuid, name, icon, state}, ...]
 System.notify({ title, message, duration });  // notification:show イベントを発行
 System.sendMessage(targetUuid, data);         // アプリ間 IPC
 System.setShellMode("desktop" | "mobile" | "auto"); // シェルモード切替 ("auto" で自動検出復帰)
@@ -36,6 +36,7 @@ System.registry     // ESKitRegistry
 System.permissions  // ESKitPermissions
 System.users        // ESKitUsers
 System.shellMode    // ESKitShellMode
+System.icons        // ESKitIcons
 System.WindowSystem // ESKitWindowSystem (ブート後)
 ```
 
@@ -102,6 +103,61 @@ System.shellMode.unlock();      // 自動検出を再開し、ビューポート
 |--------|------|
 | `"desktop"` | 複数ウィンドウのカード形式。タスクバー・ランチャーが表示される |
 | `"mobile"` | 1 画面 1 アプリの全画面形式。ホームバー・ドロワーが表示される |
+
+---
+
+## `System.icons` — アイコンレジストリ & `<eskit-icon>`
+
+アイコンセット（Icon Set）を管理し、SVG アイコンを描画する `ESKitIcons` インスタンスおよび Web Component です。
+
+```js
+// アイコンの存在確認と SVG 内部コンテンツ取得
+System.icons.has("lucide", "search");  // true
+System.icons.get("lucide", "search");  // '<circle cx="11" cy="11" r="8"/>...'
+
+// アイコンセット一覧とアイコン一覧
+System.icons.listSets();               // ["lucide"]
+System.icons.listIcons("lucide");      // ["minus", "square", "search", ...]
+
+// 独自アイコンセットの登録 (アプリ・プラグイン拡張)
+System.icons.registerSet("my-icons", {
+  "custom-star": '<polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>',
+});
+
+// マニフェスト icon 定義から DOM 要素を生成
+const appIcon = System.icons.createAppIcon(manifest.icon, { size: 24 });
+```
+
+### `<eskit-icon>` Web Component
+
+```html
+<eskit-icon set="lucide" name="search" size="18"></eskit-icon>
+<eskit-icon set="lucide" name="x" size="14" stroke-width="2.5" color="#ef4444"></eskit-icon>
+```
+
+| 属性 | 型 | デフォルト | 説明 |
+|------|----|-----------|------|
+| `set` | string | `"lucide"` | アイコンセット名 |
+| `name` | string | (必須) | アイコン名 |
+| `size` | string/number | `1em` | サイズ（数値の場合は `px` 単位） |
+| `stroke-width` | string/number | `2` | 線の太さ |
+| `color` | string | `currentColor` | アイコン色 |
+
+### `icon(set, name, options)` ヘルパー関数
+
+Hamon テンプレートや動的 DOM 構築で利用できるヘルパー関数です。`<eskit-icon>` DOM 要素を返します。
+
+```js
+import { icon } from "system/icons.js";
+
+// Hamon テンプレート内
+const template = hamon`
+  <button class="kit-button">
+    ${icon("lucide", "sparkles", { size: 16 })}
+    <span>クリック</span>
+  </button>
+`;
+```
 
 ---
 
@@ -499,8 +555,9 @@ await this.fs.rename(oldPath, newPath)// リネーム/移動 (permissions: "fs.w
 | プロパティ | 説明 |
 |----------|------|
 | `this.name` | アプリ表示名 (コンストラクタクラス名、または `setTitle()` で変更) |
+| `this.manifest` | 読み取り専用・イミュータブルな `Manifest` オブジェクト |
 | `this._uuid` | アプリ固有の UUID |
-| `this._manifest` | `define.json` から読み込まれた Manifest |
+| `this._manifest` | `define.json` から読み込まれた Manifest (内部用) |
 | `this._state` | `"running"`, `"minimized"`, `"maximized"`, `"closed"` |
 | `this._windowElement` | 対応する `<eskit-window>` 要素 |
 
@@ -569,7 +626,11 @@ await System.registry.registerFromUrl("https://example.com/myapp/");
   "entry":       "main.js",
   "version":     "1.0.0",
   "description": "アプリの説明",
-  "icon":        "icon.png",
+  "icon": {
+    "type": "set",
+    "set": "lucide",
+    "name": "sparkles"
+  },
   "permissions": ["fs.read", "notifications"]
 }
 ```
@@ -581,7 +642,7 @@ await System.registry.registerFromUrl("https://example.com/myapp/");
 | `entry` | ✅ | エントリポイント JS ファイル名 |
 | `version` | — | バージョン文字列 (省略時 `"0.0.1"`) |
 | `description` | — | アプリの説明 |
-| `icon` | — | アイコン画像のファイル名 |
+| `icon` | — | アイコンオブジェクト (`{ type: "set", set?: "lucide", name }` または `{ type: "image", src }`) |
 | `permissions` | — | 要求権限の配列 |
 
 ---

--- a/PLAN.md
+++ b/PLAN.md
@@ -503,6 +503,73 @@ ESKitSystem.constructor()
 
 ---
 
+## Phase 4.8: Icon System — アイコンセットと Lucide Icons 統合
+
+**目的:** 絵文字や記号文字に依存していたシステム UI（ウィンドウ操作、コンテキストメニュー、Beacon、タスクバー、ランチャー、ドロワー、クイック設定、ログイン画面等）およびアプリのアイコン表示を刷新し、**アイコンセット (Icon Set)** の概念に基づいた一貫性のある Lucide Icons 基盤を導入する。  
+**完了条件:** `<eskit-icon set="..." name="...">` Web Component および `icon(set, name, options)` ヘルパーが動作し、`System.icons` レジストリによりセット単位でアイコンが管理・描画され、`define.json` マニフェストの `icon` オブジェクト指定が解釈・表示される。  
+**ステータス:** 完了
+
+### 設計方針・決定事項
+
+- **アイコンセット (Icon Set) モデル:** アイコンは単一の `name` ではなく、**`set` (アイコンセット名) と `name` (アイコン名)** の 2 つのキーで常に明示的に解決する（`<eskit-icon set="lucide" name="search">`）。
+- **ビルド不要・完全ローカル自己完結:** 外部 CDN や npm ビルドに一切依存せず、`system/icons.js` に標準の `"lucide"` アイコンセットの SVG 定義を同期マップとして保持する。
+- **Web Component `<eskit-icon>`:**
+  - 属性: `set`, `name`, `size`, `stroke-width`, `color`
+  - スタイル: `display: inline-flex`, `vertical-align: middle`, `color: currentColor`, デフォルトサイズ `1em`。CSS 変数 `--eskit-icon-size`, `--eskit-icon-stroke-width` によるオーバーライドに対応。
+- **ヘルパー関数 `icon(set, name, options)`:**
+  - Hamon テンプレートや動的 DOM 生成向けに、`<eskit-icon>` 要素または SVG ノードを返す関数を提供。
+- **マニフェスト (`define.json`) 形式:**
+  - `icon` フィールドはオブジェクト形式 `{ type: "set" | "image", ... }` で統一:
+    - アイコンセット: `{ "type": "set", "set": "lucide", "name": "terminal" }`
+    - 画像ファイル: `{ "type": "image", "src": "icon.png" }`
+
+### `system/icons.js` — アイコンレジストリ (新規)
+
+**ESKitIcons:**
+```js
+class ESKitIcons {
+  registerSet(setId: string, icons: Record<string, string>): void
+  get(setId: string, name: string): string | null
+  has(setId: string, name?: string): boolean
+  listSets(): string[]
+  listIcons(setId: string): string[]
+}
+```
+
+- **組み込みセット (`lucide`):**
+  - OS 起動時に `system/icons.js` 内の主要 Lucide アイコン（約50〜100種: ウィンドウ制御、検索、設定、ファイル、ターミナル、電源、ユーザー、テーマ、各種状態表示等）を `"lucide"` セットとして同期登録。
+- **アプリによる拡張:**
+  - アプリやプラグインは `System.icons.registerSet("my-app-set", { icon1: "<svg...>...", ... })` により独自のアイコンセットを登録可能。
+
+### `system/elements/icon/` (新規)
+
+**ESKitIconElement (`eskit-icon`):**
+```html
+<eskit-icon set="lucide" name="search" size="18"></eskit-icon>
+```
+- Shadow DOM 内で SVG を描画。`currentColor` に追従。
+- `observedAttributes`: `["set", "name", "size", "stroke-width", "color"]`
+- `set` または `name` 変更時に `System.icons.get(set, name)` を再取得して描画。存在しない場合はフォールバック表示。
+
+### 既存 UI / アプリの Lucide アイコン置換スコープ
+
+| コンポーネント | 対象箇所 | 置換前 | 置換後 (`set="lucide"`) |
+|--------------|---------|-------|------------------------|
+| `eskit-window` | タイトルバー操作ボタン | `–`, `□`, `✕` | `minus`, `square` / `maximize-2`, `x` |
+| `eskit-context-menu` | デフォルトメニュー項目 | `💠`, `🔍`, `🔄` | `monitor-smartphone`, `search`, `refresh-cw` |
+| `eskit-beacon` | 検索バー・結果フォールバック | `🔍`, `🪄` | `search`, `sparkles` |
+| `eskit-launcher` | ランチャーボタン・アプリアイコン | `🪄` | マニフェストの `icon` または `sparkles` |
+| `eskit-drawer` | ドロワーアプリアイコン | `🪄` | マニフェストの `icon` または `sparkles` |
+| `eskit-quick-settings` | モード、テーマ、システム項目 | 文字/記号 | `monitor-smartphone`, `sun`, `moon`, `cpu`, `hard-drive` |
+| `eskit-login-screen` | 入力欄・ボタン | 文字 | `user`, `lock`, `arrow-right` |
+| `apps/eskish/` | マニフェスト `icon` | `"icon.png"` | `{ "type": "set", "set": "lucide", "name": "terminal" }` |
+| `apps/welcome/` | マニフェスト `icon` | `"icon.png"` | `{ "type": "set", "set": "lucide", "name": "sparkles" }` |
+| `apps/test/` | 検証状態アイコン | `⏳`, `✅`, `❌` | `clock`, `check-circle-2`, `x-circle` |
+
+**関連ファイル:** `system/icons.js` (新規), `system/elements/icon/main.js` (新規), `system/elements/icon/style.js` (新規), `system/manifest.js` (変更), `system/window.js` (変更), `system/system.js` (変更), 各種既存要素・アプリ (変更)
+
+---
+
 ## Phase 5: System Services — システムサービス
 
 **目的:** テーマシステム、通知、i18n、設定アプリの基盤サービスを実装する。  
@@ -703,6 +770,7 @@ system/
   kitstrap2.css         (実装済み)
   hamon.js              (Phase 3.5)
   users.js              (Phase 4)
+  icons.js              (Phase 4.8)
   theme.js              (Phase 5)
   themes/               (Phase 5)
     light.json
@@ -723,6 +791,7 @@ system/
     beacon/             (Phase 3)
     quick-settings/     (Phase 3)
     login-screen/       (Phase 4)
+    icon/               (Phase 4.8)
     notification/       (Phase 5)
 apps/
   test/

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,29 @@
+# Third Party Licenses
+
+This project includes or adapts code and assets from third-party open-source projects under their respective licenses.
+
+---
+
+## Lucide Icons
+
+- **Website:** https://lucide.dev
+- **Repository:** https://github.com/lucide-icons/lucide
+- **License:** ISC License
+
+```
+ISC License
+
+Copyright (c) for portions of Lucide are held by Cole Bemis 2013-2022 as part of Feather (MIT). All other copyright (c) for Lucide are held by Lucide Contributors 2022.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+```

--- a/apps/eskish/define.json
+++ b/apps/eskish/define.json
@@ -4,7 +4,11 @@
   "entry": "main.js",
   "version": "1.0.0",
   "description": "ESKit 標準ターミナル環境",
-  "icon": "icon.png",
+  "icon": {
+    "type": "set",
+    "set": "lucide",
+    "name": "terminal"
+  },
   "permissions": [
     "fs.read",
     "fs.write",

--- a/apps/test/define.json
+++ b/apps/test/define.json
@@ -4,5 +4,10 @@
   "entry": "main.js",
   "version": "1.0.0",
   "description": "ESKit システム機能の網羅的な検証アプリ",
+  "icon": {
+    "type": "set",
+    "set": "lucide",
+    "name": "check-circle-2"
+  },
   "permissions": ["fs.read", "fs.write", "notifications", "ipc", "system.info"]
 }

--- a/apps/test/main.js
+++ b/apps/test/main.js
@@ -29,8 +29,14 @@ export default class SystemVerifier extends ESKitApp {
     this.template = hamon`
       <div class="runner">
         <div class="toolbar">
-          <button @click=${() => this.#runAll()} class="kit-button -primary -small">▶ Run All Tests</button>
-          <button @click=${() => this.#testNotify()} class="kit-button -small">🔔 Test Notification</button>
+          <button @click=${() => this.#runAll()} class="kit-button -primary -small kit-flex kit-items-center kit-gap-xs">
+            <eskit-icon set="lucide" name="sparkles" size="14"></eskit-icon>
+            Run All Tests
+          </button>
+          <button @click=${() => this.#testNotify()} class="kit-button -small kit-flex kit-items-center kit-gap-xs">
+            <eskit-icon set="lucide" name="bell" size="14"></eskit-icon>
+            Test Notification
+          </button>
           <span :class=${() => `summary ${this.#summaryClass.value}`}>${() => this.#summaryText.value}</span>
         </div>
         <ol id="results" class="results">
@@ -48,7 +54,12 @@ export default class SystemVerifier extends ESKitApp {
                   const { pass } = item.state.value;
                   return `result ${pass === null ? "run" : pass ? "pass" : "fail"}`;
                 }}>
-                  <span class="icon">${() => { const { pass } = item.state.value; return pass === null ? "⏳" : pass ? "✅" : "❌"; }}</span>
+                  <span class="icon">${() => {
+                    const { pass } = item.state.value;
+                    if (pass === null) return hamon`<eskit-icon set="lucide" name="clock" size="14"></eskit-icon>`;
+                    if (pass) return hamon`<eskit-icon set="lucide" name="check-circle-2" size="14" color="var(--kit-color-success, #22c55e)"></eskit-icon>`;
+                    return hamon`<eskit-icon set="lucide" name="x-circle" size="14" color="var(--kit-color-danger, #ef4444)"></eskit-icon>`;
+                  }}</span>
                   <span class="name">${item.name}</span>
                   <span class="detail">${() => item.state.value.detail ?? ""}</span>
                 </li>
@@ -124,6 +135,14 @@ export default class SystemVerifier extends ESKitApp {
       () => this.#testSetTitle(),
       () => this.#testQuerySelector(),
       () => this.#testQuerySelectorAll(),
+    ]);
+
+    await this.#runSection("Icon System (ESKitIcons & <eskit-icon>)", [
+      () => this.#testIconRegistryGetHas(),
+      () => this.#testIconRegistryRegisterSet(),
+      () => this.#testIconElementRender(),
+      () => this.#testIconElementFallback(),
+      () => this.#testCreateAppIcon(),
     ]);
 
     this.#updateSummary();
@@ -482,6 +501,98 @@ export default class SystemVerifier extends ESKitApp {
       const buttons = this.querySelectorAll("button");
       this.#assert(buttons.length >= 2, `length=${buttons.length}`);
       return `${buttons.length} buttons`;
+    });
+  }
+
+  // ─── Icon System テスト ───────────────────────────────────────────────────
+
+  async #testIconRegistryGetHas() {
+    await this.#test("Icons: System.icons.get() & has()", () => {
+      this.#assert(System.icons !== undefined, "System.icons is undefined");
+      this.#assert(System.icons.has("lucide"), "lucide set not found");
+      this.#assert(System.icons.has("lucide", "search"), "lucide:search not found");
+      this.#assert(!System.icons.has("lucide", "non_existent_icon_xyz"), "non-existent icon found");
+
+      const svgContent = System.icons.get("lucide", "search");
+      this.#assert(typeof svgContent === "string" && svgContent.length > 0, "svgContent is invalid");
+      return "OK";
+    });
+  }
+
+  async #testIconRegistryRegisterSet() {
+    await this.#test("Icons: System.icons.registerSet() & listSets()", () => {
+      System.icons.registerSet("test-custom-set", {
+        "custom-star": '<polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>',
+      });
+      this.#assert(System.icons.has("test-custom-set", "custom-star"), "custom icon not registered");
+      this.#assert(System.icons.listSets().includes("test-custom-set"), "test-custom-set not in listSets");
+      this.#assert(System.icons.listIcons("test-custom-set").includes("custom-star"), "custom-star not in listIcons");
+      return "OK";
+    });
+  }
+
+  async #testIconElementRender() {
+    await this.#test("Icons: <eskit-icon> DOM レンダリング & 属性反映", () => {
+      const el = document.createElement("eskit-icon");
+      el.setAttribute("set", "lucide");
+      el.setAttribute("name", "terminal");
+      el.setAttribute("size", "24");
+      el.setAttribute("color", "#ff0000");
+
+      const container = document.createElement("div");
+      container.appendChild(el);
+      document.body.appendChild(container);
+
+      try {
+        const svg = el.shadowRoot?.querySelector("svg");
+        this.#assert(svg !== null, "SVG element not rendered in shadowRoot");
+        this.#assert(el.style.width === "24px", `width=${el.style.width}`);
+        this.#assert(el.style.color === "rgb(255, 0, 0)", `color=${el.style.color}`);
+      } finally {
+        container.remove();
+      }
+      return "OK";
+    });
+  }
+
+  async #testIconElementFallback() {
+    await this.#test("Icons: 未登録アイコン指定時のフォールバック (help-circle)", () => {
+      const el = document.createElement("eskit-icon");
+      el.setAttribute("set", "lucide");
+      el.setAttribute("name", "unknown_missing_icon");
+
+      const container = document.createElement("div");
+      container.appendChild(el);
+      document.body.appendChild(container);
+
+      try {
+        const svg = el.shadowRoot?.querySelector("svg");
+        this.#assert(svg !== null, "SVG element not rendered");
+        this.#assert(svg.innerHTML.length > 0, "SVG innerHTML is empty on fallback");
+      } finally {
+        container.remove();
+      }
+      return "OK";
+    });
+  }
+
+  async #testCreateAppIcon() {
+    await this.#test("Icons: System.icons.createAppIcon() (set & image)", () => {
+      // 1. set 指定
+      const setIcon = System.icons.createAppIcon({ type: "set", set: "lucide", name: "terminal" }, { size: 20 });
+      this.#assert(setIcon.tagName.toLowerCase() === "eskit-icon", "setIcon is not <eskit-icon>");
+      this.#assert(setIcon.getAttribute("name") === "terminal", "setIcon name != terminal");
+
+      // 2. image 指定
+      const imgIcon = System.icons.createAppIcon({ type: "image", src: "icon.png" }, { size: 20 });
+      this.#assert(imgIcon.tagName.toLowerCase() === "img", "imgIcon is not <img>");
+      this.#assert(imgIcon.getAttribute("src") === "icon.png", "imgIcon src != icon.png");
+
+      // 3. null フォールバック
+      const nullIcon = System.icons.createAppIcon(null, { size: 20 });
+      this.#assert(nullIcon.tagName.toLowerCase() === "eskit-icon", "nullIcon is not <eskit-icon>");
+      this.#assert(nullIcon.getAttribute("name") === "package", "nullIcon name != package");
+      return "OK";
     });
   }
 

--- a/apps/test/style.js
+++ b/apps/test/style.js
@@ -47,7 +47,7 @@ export default css`
     display: grid;
     grid-template-columns: 1.2rem 1fr auto;
     gap: var(--kit-space-xs);
-    align-items: baseline;
+    align-items: center;
     padding: 0.18rem var(--kit-space-s);
   }
 

--- a/apps/welcome/define.json
+++ b/apps/welcome/define.json
@@ -4,5 +4,10 @@
   "entry": "main.js",
   "version": "1.0.0",
   "description": "ようこそアプリ",
+  "icon": {
+    "type": "set",
+    "set": "lucide",
+    "name": "sparkles"
+  },
   "permissions": []
 }

--- a/system/app.js
+++ b/system/app.js
@@ -31,6 +31,18 @@ export default class ESKitApp {
     // Note: initialize() は ESKitSystem が _windowElement 注入後に呼び出す
   }
 
+  /**
+   * アプリマニフェスト（読み取り専用・イミュータブルコピー）
+   * @returns {Readonly<object>|null}
+   */
+  get manifest() {
+    if (!this._manifest) return null;
+    return Object.freeze({
+      ...this._manifest,
+      permissions: Object.freeze([...(this._manifest.permissions || [])]),
+    });
+  }
+
   // ─── ライフサイクルフック (サブクラスでオーバーライド) ──────────────────────
 
   /** アプリ起動時に呼ばれる。querySelector() 使用可。 */

--- a/system/elements/beacon/main.js
+++ b/system/elements/beacon/main.js
@@ -78,13 +78,21 @@ export default class ESKitBeaconElement extends HTMLElement {
       const manifest = this.#currentResults[i];
       const btn = document.createElement("button");
       btn.className = `result-item${i === this.#selectedIndex ? " -selected" : ""}`;
-      btn.innerHTML = `
-        <span class="result-icon">🪄</span>
-        <span class="result-info">
-          <span class="result-name">${this.#esc(manifest.name)}</span>
-          <span class="result-desc">${this.#esc(manifest.description || manifest.id)}</span>
-        </span>
+
+      const iconSpan = document.createElement("span");
+      iconSpan.className = "result-icon";
+      const iconEl = window.System?.icons?.createAppIcon(manifest.icon, { size: 18 });
+      if (iconEl) iconSpan.appendChild(iconEl);
+
+      const infoSpan = document.createElement("span");
+      infoSpan.className = "result-info";
+      infoSpan.innerHTML = `
+        <span class="result-name">${this.#esc(manifest.name)}</span>
+        <span class="result-desc">${this.#esc(manifest.description || manifest.id)}</span>
       `;
+
+      btn.appendChild(iconSpan);
+      btn.appendChild(infoSpan);
       btn.addEventListener("click", () => this.#launch(manifest));
       this.#resultsEl.appendChild(btn);
     }

--- a/system/elements/beacon/style.js
+++ b/system/elements/beacon/style.js
@@ -48,6 +48,9 @@ export default css`
 
   .beacon-icon {
     font-size: var(--kit-font-size-l);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     flex-shrink: 0;
     line-height: 1;
   }

--- a/system/elements/beacon/template.js
+++ b/system/elements/beacon/template.js
@@ -3,7 +3,7 @@ export default html`
   <div class="beacon-overlay" id="overlay">
     <div class="beacon-panel">
       <div class="beacon-header">
-        <span class="beacon-icon">🔍</span>
+        <span class="beacon-icon"><eskit-icon set="lucide" name="search" size="18"></eskit-icon></span>
         <input type="text" id="beacon-input" class="kit-textbox kit-flex-fit -rounded" placeholder="アプリを検索…" autocomplete="off">
       </div>
       <div class="beacon-results" id="beacon-results"></div>

--- a/system/elements/context-menu/main.js
+++ b/system/elements/context-menu/main.js
@@ -92,7 +92,18 @@ export default class ESKitContextMenuElement extends HTMLElement {
       const btn = document.createElement("button");
       btn.className = "menu-item";
       if (item.icon) {
-        btn.innerHTML = `<span class="menu-item-icon">${this.#esc(item.icon)}</span>${this.#esc(item.label)}`;
+        let iconHtml = "";
+        if (typeof item.icon === "object" && item.icon.name) {
+          const set = item.icon.set || "lucide";
+          iconHtml = `<eskit-icon set="${this.#esc(set)}" name="${this.#esc(item.icon.name)}" size="16"></eskit-icon>`;
+        } else if (typeof item.icon === "string") {
+          if (window.System?.icons?.has("lucide", item.icon)) {
+            iconHtml = `<eskit-icon set="lucide" name="${this.#esc(item.icon)}" size="16"></eskit-icon>`;
+          } else {
+            iconHtml = this.#esc(item.icon);
+          }
+        }
+        btn.innerHTML = `<span class="menu-item-icon">${iconHtml}</span><span>${this.#esc(item.label)}</span>`;
       } else {
         btn.textContent = item.label;
       }

--- a/system/elements/context-menu/style.js
+++ b/system/elements/context-menu/style.js
@@ -50,7 +50,9 @@ export default css`
 
   .menu-item-icon {
     width: 1.2em;
-    text-align: center;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     flex-shrink: 0;
   }
 

--- a/system/elements/drawer/main.js
+++ b/system/elements/drawer/main.js
@@ -101,13 +101,22 @@ export default class ESKitDrawerElement extends HTMLElement {
       return;
     }
 
-    for (const { uuid, name } of processes) {
+    for (const { uuid, name, icon } of processes) {
       const btn = document.createElement("button");
       btn.className = "app-card";
-      btn.innerHTML = `
-        <span class="app-icon">🪄</span>
-        <span class="app-name">${this.#esc(name)}</span>
-      `;
+
+      const iconSpan = document.createElement("span");
+      iconSpan.className = "app-icon";
+      const iconEl = window.System?.icons?.createAppIcon(icon, { size: 32 });
+      if (iconEl) iconSpan.appendChild(iconEl);
+
+      const nameSpan = document.createElement("span");
+      nameSpan.className = "app-name";
+      nameSpan.textContent = name;
+
+      btn.appendChild(iconSpan);
+      btn.appendChild(nameSpan);
+
       btn.addEventListener("click", () => {
         window.System?.WindowSystem?.activateWindow(uuid);
         this.close();
@@ -124,10 +133,19 @@ export default class ESKitDrawerElement extends HTMLElement {
     for (const manifest of manifests) {
       const btn = document.createElement("button");
       btn.className = "app-card grid-card";
-      btn.innerHTML = `
-        <span class="app-icon">🪄</span>
-        <span class="app-name">${this.#esc(manifest.name)}</span>
-      `;
+
+      const iconSpan = document.createElement("span");
+      iconSpan.className = "app-icon";
+      const iconEl = window.System?.icons?.createAppIcon(manifest.icon, { size: 32 });
+      if (iconEl) iconSpan.appendChild(iconEl);
+
+      const nameSpan = document.createElement("span");
+      nameSpan.className = "app-name";
+      nameSpan.textContent = manifest.name;
+
+      btn.appendChild(iconSpan);
+      btn.appendChild(nameSpan);
+
       btn.addEventListener("click", async () => {
         // manifest._dir は registry.list() が付与する
         if (manifest._dir) {

--- a/system/elements/drawer/template.js
+++ b/system/elements/drawer/template.js
@@ -5,11 +5,11 @@ export default html`
     <div class="drawer-topbar">
       <span class="drawer-time" id="drawer-time"></span>
       <button class="qs-open-btn" id="qs-btn" title="クイック設定">
-        <span>⚙️</span>
+        <eskit-icon set="lucide" name="settings" size="16"></eskit-icon>
         <span class="qs-open-label">設定</span>
       </button>
       <button class="qs-open-btn" id="beacon-btn" title="検索">
-        <span>🔍</span>
+        <eskit-icon set="lucide" name="search" size="16"></eskit-icon>
         <span class="qs-open-label">検索</span>
       </button>
     </div>

--- a/system/elements/home-bar/template.js
+++ b/system/elements/home-bar/template.js
@@ -1,5 +1,5 @@
 import { html } from "system/util.js";
 export default html`
-  <button class="home-btn kit-button -flat" id="home-btn" title="ホーム / ドロワー">💠</button>
+  <button class="home-btn kit-button -flat" id="home-btn" title="ホーム / ドロワー"><eskit-icon set="lucide" name="boxes" size="20"></eskit-icon></button>
   <span class="current-app" id="current-app-name"></span>
 `;

--- a/system/elements/icon/main.js
+++ b/system/elements/icon/main.js
@@ -1,0 +1,89 @@
+import style from "./style.js";
+
+/**
+ * ESKitIconElement (`<eskit-icon>`) — アイコン表示用 Web Component
+ *
+ * 属性:
+ *   set          — アイコンセット名 (デフォルト: "lucide")
+ *   name         — アイコン名 (例: "search", "terminal")
+ *   size         — 表示サイズ (数値または単位付き文字列。例: "18", "1.5rem")
+ *   stroke-width — 線の太さ (デフォルト: 2)
+ *   color        — アイコン色 (デフォルト: currentColor)
+ */
+export default class ESKitIconElement extends HTMLElement {
+  static get observedAttributes() {
+    return ["set", "name", "size", "stroke-width", "color"];
+  }
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    const sheet = new CSSStyleSheet();
+    sheet.replaceSync(style);
+    this.shadowRoot.adoptedStyleSheets = [sheet];
+  }
+
+  connectedCallback() {
+    this.#render();
+  }
+
+  attributeChangedCallback(name, oldValue, newValue) {
+    if (oldValue === newValue) return;
+    this.#render();
+  }
+
+  #render() {
+    const set = this.getAttribute("set") || "lucide";
+    const name = this.getAttribute("name");
+    const size = this.getAttribute("size");
+    const strokeWidth = this.getAttribute("stroke-width") || "2";
+    const color = this.getAttribute("color");
+
+    // サイズスタイルの適用
+    if (size) {
+      const sizeVal = /^\d+(\.\d+)?$/.test(size.trim()) ? `${size}px` : size;
+      this.style.width = sizeVal;
+      this.style.height = sizeVal;
+    } else {
+      this.style.removeProperty("width");
+      this.style.removeProperty("height");
+    }
+
+    // カラースタイルの適用
+    if (color) {
+      this.style.color = color;
+    } else {
+      this.style.removeProperty("color");
+    }
+
+    if (!name) {
+      this.shadowRoot.innerHTML = "";
+      return;
+    }
+
+    // アイコン SVG 内部コンテンツを取得
+    let svgInner = window.System?.icons?.get(set, name);
+
+    if (svgInner === null || svgInner === undefined) {
+      // フォールバック: help-circle を試行
+      svgInner = window.System?.icons?.get("lucide", "help-circle") || "";
+      if (window.System?.icons) {
+        console.warn(`[eskit-icon] Icon not found: set="${set}", name="${name}"`);
+      }
+    }
+
+    this.shadowRoot.innerHTML = `
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="${strokeWidth}"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        ${svgInner}
+      </svg>
+    `;
+  }
+}

--- a/system/elements/icon/style.js
+++ b/system/elements/icon/style.js
@@ -1,0 +1,24 @@
+import { css } from "system/util.js";
+
+export default css`
+  :host {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    vertical-align: middle;
+    line-height: 0;
+    width: var(--eskit-icon-size, 1em);
+    height: var(--eskit-icon-size, 1em);
+    color: inherit;
+    box-sizing: border-box;
+    pointer-events: none;
+    user-select: none;
+  }
+
+  svg {
+    width: 100%;
+    height: 100%;
+    display: block;
+    overflow: visible;
+  }
+`;

--- a/system/elements/launcher/main.js
+++ b/system/elements/launcher/main.js
@@ -91,10 +91,19 @@ export default class ESKitLauncherElement extends HTMLElement {
     for (const manifest of manifests) {
       const btn = document.createElement("button");
       btn.className = "app-card";
-      btn.innerHTML = `
-        <span class="app-icon">🪄</span>
-        <span class="app-name">${this.#esc(manifest.name)}</span>
-      `;
+
+      const iconSpan = document.createElement("span");
+      iconSpan.className = "app-icon";
+      const iconEl = window.System?.icons?.createAppIcon(manifest.icon, { size: 32 });
+      if (iconEl) iconSpan.appendChild(iconEl);
+
+      const nameSpan = document.createElement("span");
+      nameSpan.className = "app-name";
+      nameSpan.textContent = manifest.name;
+
+      btn.appendChild(iconSpan);
+      btn.appendChild(nameSpan);
+
       btn.addEventListener("click", async () => {
         if (manifest._dir) {
           await window.System?.loadApp(manifest._dir);

--- a/system/elements/login-screen/main.js
+++ b/system/elements/login-screen/main.js
@@ -85,7 +85,9 @@ export default class ESKitLoginScreenElement extends HTMLElement {
 
   #setSubmitLabel(text) {
     const el = this.shadowRoot.getElementById("submit");
-    if (el) el.textContent = text;
+    if (el) {
+      el.innerHTML = `<span class="kit-flex kit-items-center kit-gap-xs"><span>${text}</span><eskit-icon set="lucide" name="arrow-right" size="14"></eskit-icon></span>`;
+    }
   }
 
   #setError(message) {

--- a/system/elements/login-screen/template.js
+++ b/system/elements/login-screen/template.js
@@ -7,12 +7,18 @@ export default html`
 
     <form id="form" class="form" autocomplete="off" novalidate>
       <div class="field" id="field-login-user">
-        <label for="login-user-id">ユーザー</label>
+        <label for="login-user-id" class="kit-flex kit-items-center kit-gap-xs">
+          <eskit-icon set="lucide" name="user" size="14"></eskit-icon>
+          ユーザー
+        </label>
         <select id="login-user-id"></select>
       </div>
 
       <div class="field">
-        <label for="password">パスワード</label>
+        <label for="password" class="kit-flex kit-items-center kit-gap-xs">
+          <eskit-icon set="lucide" name="lock" size="14"></eskit-icon>
+          パスワード
+        </label>
         <input id="password" type="password">
       </div>
 

--- a/system/elements/permission-dialog/style.js
+++ b/system/elements/permission-dialog/style.js
@@ -32,6 +32,10 @@ export default css`
   /* ─── テキスト ──────────────────────────────────────────────── */
 
   .title {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--kit-space-xs);
     margin: 0 0 var(--kit-space-s);
     font-size: var(--kit-font-size-m);
     font-weight: var(--kit-font-weight-bold);

--- a/system/elements/permission-dialog/template.js
+++ b/system/elements/permission-dialog/template.js
@@ -1,7 +1,10 @@
 import { html } from "system/util.js";
 export default html`
   <div class="dialog" part="dialog" role="dialog" aria-modal="true" aria-labelledby="perm-title">
-    <h3 class="title" id="perm-title">アクセス許可の要求</h3>
+    <h3 class="title kit-flex kit-items-center kit-gap-xs" id="perm-title">
+      <eskit-icon set="lucide" name="shield" size="18"></eskit-icon>
+      <span>アクセス許可の要求</span>
+    </h3>
     <p class="description" id="perm-desc"></p>
     <code class="perm-badge" id="perm-badge"></code>
     <div class="actions">

--- a/system/elements/quick-settings/style.js
+++ b/system/elements/quick-settings/style.js
@@ -8,11 +8,13 @@ export default css`
   .quick-settings {
     position: fixed;
     margin: 0;
+    padding: 0;
     inset: unset;
     bottom: calc(var(--eskit-taskbar-height, 48px) + var(--kit-space-s));
     right: var(--kit-space-s);
     width: 280px;
     background: var(--eskit-color-surface, var(--eskit-color-background));
+    color: var(--eskit-color-text, var(--kit-fg));
     border: 1px solid var(--eskit-color-border);
     border-radius: var(--kit-radius-m);
     box-shadow: var(--kit-shadow-8);
@@ -51,6 +53,16 @@ export default css`
     border-bottom: 1px solid var(--eskit-color-border);
   }
 
+  .qs-header-title {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--kit-space-xs);
+    font-size: var(--kit-font-size-s);
+    font-weight: var(--kit-font-weight-bold);
+    line-height: 1;
+    color: var(--eskit-color-text, var(--kit-fg));
+  }
+
   .qs-section {
     padding: var(--kit-space-s) var(--kit-space-m);
     display: flex;
@@ -66,13 +78,36 @@ export default css`
   }
 
   .qs-label {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--kit-space-xs);
     font-size: var(--kit-font-size-s);
-    color: var(--eskit-color-text);
+    line-height: 1;
+    color: var(--eskit-color-text, var(--kit-fg));
     flex-shrink: 0;
   }
 
   .qs-value {
+    font-size: var(--kit-font-size-s);
+    line-height: 1.2;
     text-align: right;
+    color: var(--eskit-color-text, var(--kit-fg));
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .qs-value.-muted {
+    color: var(--eskit-color-text-muted, var(--kit-fg-secondary));
+  }
+
+  .logout-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--kit-space-xs);
+    line-height: 1;
+    width: 100%;
   }
 
   .qs-divider {
@@ -82,6 +117,10 @@ export default css`
   }
 
   /* ─── モード切替ボタン ─────────────────────────────────── */
+
+  .mode-btn {
+    line-height: 1;
+  }
 
   .mode-btn.-active {
     background: var(--eskit-color-primary);
@@ -116,4 +155,3 @@ export default css`
     transform: translateY(-100%);
   }
 `;
-

--- a/system/elements/quick-settings/template.js
+++ b/system/elements/quick-settings/template.js
@@ -2,16 +2,25 @@ import { html } from "system/util.js";
 export default html`
   <div class="quick-settings" popover="manual" id="panel">
     <div class="qs-header">
-      <span class="kit-font-s kit-font-bold">クイック設定</span>
+      <span class="qs-header-title">
+        <eskit-icon set="lucide" name="sliders" size="14"></eskit-icon>
+        <span>クイック設定</span>
+      </span>
     </div>
 
     <div class="qs-section">
       <div class="qs-row">
-        <span class="qs-label">ユーザー</span>
-        <span class="qs-value kit-font-s" id="current-user">(未ログイン)</span>
+        <span class="qs-label">
+          <eskit-icon set="lucide" name="user" size="14"></eskit-icon>
+          <span>ユーザー</span>
+        </span>
+        <span class="qs-value" id="current-user">(未ログイン)</span>
       </div>
       <div class="qs-row">
-        <button class="kit-button -small" id="logout-btn">ログアウト</button>
+        <button class="kit-button -small logout-btn" id="logout-btn">
+          <eskit-icon set="lucide" name="power" size="14"></eskit-icon>
+          <span>ログアウト</span>
+        </button>
       </div>
     </div>
 
@@ -19,7 +28,10 @@ export default html`
 
     <div class="qs-section">
       <div class="qs-row">
-        <span class="qs-label">シェルモード</span>
+        <span class="qs-label">
+          <eskit-icon set="lucide" name="monitor-smartphone" size="14"></eskit-icon>
+          <span>シェルモード</span>
+        </span>
         <div class="kit-buttongroup" id="mode-group">
           <button class="kit-button -small mode-btn" data-mode="auto">Auto</button>
           <button class="kit-button -small mode-btn" data-mode="desktop">Desktop</button>
@@ -32,12 +44,18 @@ export default html`
 
     <div class="qs-section">
       <div class="qs-row">
-        <span class="qs-label">テーマ</span>
-        <span class="qs-value kit-c-fg-secondary kit-font-s">Phase 5</span>
+        <span class="qs-label">
+          <eskit-icon set="lucide" name="palette" size="14"></eskit-icon>
+          <span>テーマ</span>
+        </span>
+        <span class="qs-value -muted">Phase 5</span>
       </div>
       <div class="qs-row">
-        <span class="qs-label">言語</span>
-        <span class="qs-value kit-c-fg-secondary kit-font-s">Phase 5</span>
+        <span class="qs-label">
+          <eskit-icon set="lucide" name="globe" size="14"></eskit-icon>
+          <span>言語</span>
+        </span>
+        <span class="qs-value -muted">Phase 5</span>
       </div>
     </div>
 
@@ -45,7 +63,10 @@ export default html`
 
     <div class="qs-section">
       <div class="qs-row">
-        <span class="qs-label">実行中プロセス</span>
+        <span class="qs-label">
+          <eskit-icon set="lucide" name="cpu" size="14"></eskit-icon>
+          <span>実行中プロセス</span>
+        </span>
         <span class="qs-value kit-badge -primary" id="process-count">0</span>
       </div>
     </div>

--- a/system/elements/taskbar/main.js
+++ b/system/elements/taskbar/main.js
@@ -78,8 +78,8 @@ export default class ESKitTaskbarElement extends HTMLElement {
     if (!sys) return;
 
     // アプリ起動 → ボタン追加
-    this.#offOpened = sys.events.on("app:opened", ({ uuid, name }) => {
-      this.#addAppButton(uuid, name);
+    this.#offOpened = sys.events.on("app:opened", ({ uuid, name, icon }) => {
+      this.#addAppButton(uuid, name, icon);
     });
 
     // アプリ終了 → ボタン削除
@@ -100,14 +100,22 @@ export default class ESKitTaskbarElement extends HTMLElement {
 
   // ─── アプリボタン管理 ─────────────────────────────────────────────────
 
-  #addAppButton(uuid, name) {
+  #addAppButton(uuid, name, icon) {
     const container = this.shadowRoot.getElementById("taskbar-apps");
     if (!container) return;
 
     const btn = document.createElement("button");
     btn.className = "app-btn";
     btn.dataset.uuid = uuid;
-    btn.textContent = name;
+
+    const iconEl = window.System?.icons?.createAppIcon(icon, { size: 16 });
+    if (iconEl) btn.appendChild(iconEl);
+
+    const label = document.createElement("span");
+    label.className = "app-btn-label";
+    label.textContent = name;
+    btn.appendChild(label);
+
     btn.addEventListener("click", () => {
       window.System?.WindowSystem?.activateWindow(uuid);
     });
@@ -128,7 +136,14 @@ export default class ESKitTaskbarElement extends HTMLElement {
     const container = this.shadowRoot.getElementById("taskbar-apps");
     if (!container) return;
     const btn = container.querySelector(`[data-uuid="${CSS.escape(uuid)}"]`);
-    if (btn) btn.textContent = title;
+    if (btn) {
+      const label = btn.querySelector(".app-btn-label");
+      if (label) {
+        label.textContent = title;
+      } else {
+        btn.textContent = title;
+      }
+    }
   }
 
   #setActive(uuid) {

--- a/system/elements/taskbar/style.js
+++ b/system/elements/taskbar/style.js
@@ -34,7 +34,7 @@ export default css`
   /* ─── ランチャーボタン ──────────────────────────────────────── */
 
   .launcher-btn {
-    display: flex;
+    display: inline-flex;
     align-items: center;
     justify-content: center;
     width: 2.5rem;
@@ -88,8 +88,13 @@ export default css`
     white-space: nowrap;
     max-width: 12rem;
     overflow: hidden;
-    text-overflow: ellipsis;
     flex-shrink: 0;
+  }
+
+  .app-btn-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .app-btn:hover {

--- a/system/elements/taskbar/template.js
+++ b/system/elements/taskbar/template.js
@@ -1,7 +1,7 @@
 import { html } from "system/util.js";
 export default html`
   <div class="taskbar" part="bar">
-    <button class="launcher-btn" id="launcher-btn" title="ランチャー">💠</button>
+    <button class="launcher-btn" id="launcher-btn" title="ランチャー"><eskit-icon set="lucide" name="boxes" size="18"></eskit-icon></button>
     <div class="taskbar-apps" id="taskbar-apps"></div>
     <div class="taskbar-tray">
       <span class="clock" id="clock"></span>

--- a/system/elements/window/main.js
+++ b/system/elements/window/main.js
@@ -68,6 +68,18 @@ export default class ESKitWindowElement extends HTMLElement {
   }
 
   /**
+   * ウィンドウヘッダーのアプリアイコンを更新する。
+   * @param {object|null} iconDef
+   */
+  setIcon(iconDef) {
+    const el = this.shadowRoot?.getElementById("window-icon");
+    if (!el) return;
+    el.innerHTML = "";
+    const iconEl = window.System?.icons?.createAppIcon(iconDef, { size: 16 });
+    if (iconEl) el.appendChild(iconEl);
+  }
+
+  /**
    * ウィンドウを最前面にフォーカスする。
    */
   focus() {
@@ -98,7 +110,7 @@ export default class ESKitWindowElement extends HTMLElement {
     this.#clearSnapClasses();
     this._state = "maximized";
     this.classList.add("maximized");
-    this.shadowRoot.querySelector(".btn-maximize").textContent = "❐";
+    this.shadowRoot.querySelector(".btn-maximize eskit-icon")?.setAttribute("name", "minimize-2");
   }
 
   /**
@@ -109,7 +121,7 @@ export default class ESKitWindowElement extends HTMLElement {
     this._state = "normal";
     this.classList.remove("minimized", "maximized");
     this.#clearSnapClasses();
-    this.shadowRoot.querySelector(".btn-maximize").textContent = "□";
+    this.shadowRoot.querySelector(".btn-maximize eskit-icon")?.setAttribute("name", "square");
 
     if (prev !== "minimized" && this._prevRect) {
       this.#applyRect(this._prevRect);

--- a/system/elements/window/style.js
+++ b/system/elements/window/style.js
@@ -113,6 +113,16 @@ export default css`
     cursor: default;
   }
 
+  .app-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-right: var(--kit-space-xs);
+    flex-shrink: 0;
+    line-height: 1;
+    pointer-events: none;
+  }
+
   .app-title {
     font-size: var(--kit-font-size-s);
     font-weight: var(--kit-font-weight-bold);

--- a/system/elements/window/template.js
+++ b/system/elements/window/template.js
@@ -9,11 +9,12 @@ export default html`
   <div class="resize-handle resize-se"></div>
   <div class="resize-handle resize-sw"></div>
   <div class="app-header">
+    <span class="app-icon" id="window-icon"></span>
     <span class="app-title"></span>
     <div class="app-controls">
-      <button class="btn-minimize" title="最小化">–</button>
-      <button class="btn-maximize" title="最大化">□</button>
-      <button class="btn-close" title="閉じる">✕</button>
+      <button class="btn-minimize" title="最小化"><eskit-icon set="lucide" name="minus" size="14"></eskit-icon></button>
+      <button class="btn-maximize" title="最大化"><eskit-icon set="lucide" name="square" size="12"></eskit-icon></button>
+      <button class="btn-close" title="閉じる"><eskit-icon set="lucide" name="x" size="14"></eskit-icon></button>
     </div>
   </div>
 `;

--- a/system/icons.js
+++ b/system/icons.js
@@ -1,0 +1,236 @@
+/**
+ * Lucide Icons
+ *
+ * ISC License
+ *
+ * Copyright (c) for portions of Lucide are held by Cole Bemis 2013-2022 as part of Feather (MIT).
+ * All other copyright (c) for Lucide are held by Lucide Contributors 2022.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/**
+ * 組み込み Lucide アイコンの内部 SVG 定義マップ
+ */
+const LUCIDE_ICONS = {
+  // ウィンドウ / UI 制御
+  "minus": '<line x1="5" x2="19" y1="12" y2="12"/>',
+  "square": '<rect width="18" height="18" x="3" y="3" rx="2"/>',
+  "maximize-2": '<polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" x2="14" y1="3" y2="10"/><line x1="3" x2="10" y1="21" y2="14"/>',
+  "minimize-2": '<polyline points="4 14 10 14 10 20"/><polyline points="20 10 14 10 14 4"/><line x1="14" x2="21" y1="10" y2="3"/><line x1="3" x2="10" y1="21" y2="14"/>',
+  "x": '<path d="M18 6 6 18"/><path d="m6 6 12 12"/>',
+  "sparkles": '<path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.963 0z"/><path d="M20 3v4"/><path d="M22 5h-4"/><path d="M4 17v2"/><path d="M5 18H3"/>',
+  "boxes": '<path d="M2.97 12.92A2 2 0 0 0 2 14.63v3.24a2 2 0 0 0 .97 1.71l3 1.8a2 2 0 0 0 2.06 0L12 19v-5.5l-5-3-4.03 2.42Z"/><path d="m7 16.5-4.74-2.85"/><path d="m7 16.5 5-3"/><path d="M7 16.5v5.17"/><path d="M12 13.5V19l3.97 2.38a2 2 0 0 0 2.06 0l3-1.8a2 2 0 0 0 .97-1.71v-3.24a2 2 0 0 0-.97-1.71L17 10.5l-5 3Z"/><path d="m17 16.5-5-3"/><path d="m17 16.5 4.74-2.85"/><path d="M17 16.5v5.17"/><path d="M7.97 4.42A2 2 0 0 0 7 6.13v4.37l5 3 5-3V6.13a2 2 0 0 0-.97-1.71l-3-1.8a2 2 0 0 0-2.06 0l-3 1.8Z"/><path d="M12 8 7.26 5.15"/><path d="m12 8 4.74-2.85"/><path d="M12 13.5V8"/>',
+  "package": '<path d="m7.5 4.27 9 5.15"/><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="m3.3 7 8.7 5 8.7-5"/><path d="M12 22V12"/>',
+  "box": '<path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="m3.3 7 8.7 5 8.7-5"/><path d="M12 22V12"/>',
+  "search": '<circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/>',
+  "refresh-cw": '<path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M8 16H3v5"/>',
+  "menu": '<line x1="4" x2="20" y1="12" y2="12"/><line x1="4" x2="20" y1="6" y2="6"/><line x1="4" x2="20" y1="18" y2="18"/>',
+  "chevron-left": '<path d="m15 18-6-6 6-6"/>',
+  "chevron-right": '<path d="m9 18 6-6-6-6"/>',
+  "chevron-down": '<path d="m6 9 6 6 6-6"/>',
+  "chevron-up": '<path d="m18 15-6-6-6 6"/>',
+  "arrow-right": '<path d="M5 12h14"/><path d="m12 5 7 7-7 7"/>',
+  "arrow-left": '<path d="m12 19-7-7 7-7"/><path d="M19 12H5"/>',
+
+  // システム / デバイス / 状態
+  "monitor-smartphone": '<path d="M18 8V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v7a2 2 0 0 0 2 2h8"/><path d="M10 19v-3.96 3.15"/><path d="M7 19h5"/><rect width="6" height="10" x="16" y="12" rx="2"/>',
+  "monitor": '<rect width="20" height="14" x="2" y="3" rx="2"/><line x1="8" x2="16" y1="21" y2="21"/><line x1="12" x2="12" y1="17" y2="21"/>',
+  "smartphone": '<rect width="14" height="20" x="5" y="2" rx="2" ry="2"/><path d="M12 18h.01"/>',
+  "sun": '<circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m6.34 17.66-1.41 1.41"/><path d="m19.07 4.93-1.41 1.41"/>',
+  "moon": '<path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/>',
+  "cpu": '<rect width="16" height="16" x="4" y="4" rx="2"/><rect width="6" height="6" x="9" y="9" rx="1"/><path d="M15 2v2"/><path d="M15 20v2"/><path d="M2 15h2"/><path d="M2 9h2"/><path d="M20 15h2"/><path d="M20 9h2"/><path d="M9 2v2"/><path d="M9 20v2"/>',
+  "hard-drive": '<line x1="22" x2="2" y1="12" y2="12"/><path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/><line x1="6" x2="6.01" y1="16" y2="16"/><line x1="10" x2="10.01" y1="16" y2="16"/>',
+  "user": '<path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/>',
+  "lock": '<rect width="18" height="11" x="3" y="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/>',
+  "unlock": '<rect width="18" height="11" x="3" y="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 9.9-1"/>',
+  "clock": '<circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>',
+  "bell": '<path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9"/><path d="M10.3 21a1.94 1.94 0 0 0 3.4 0"/>',
+  "shield": '<path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/>',
+  "settings": '<path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/>',
+  "power": '<path d="M12 2v10"/><path d="M18.4 6.6a9 9 0 1 1-12.77.04"/>',
+  "terminal": '<polyline points="4 17 10 11 4 5"/><line x1="12" x2="20" y1="19" y2="19"/>',
+  "palette": '<circle cx="13.5" cy="6.5" r=".5" fill="currentColor"/><circle cx="17.5" cy="10.5" r=".5" fill="currentColor"/><circle cx="8.5" cy="7.5" r=".5" fill="currentColor"/><circle cx="6.5" cy="12.5" r=".5" fill="currentColor"/><path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.563-2.512 5.563-5.563C22 6.5 17.5 2 12 2Z"/>',
+  "globe": '<circle cx="12" cy="12" r="10"/><path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"/><path d="M2 12h20"/>',
+  "layout-grid": '<rect width="7" height="7" x="3" y="3" rx="1"/><rect width="7" height="7" x="14" y="3" rx="1"/><rect width="7" height="7" x="14" y="14" rx="1"/><rect width="7" height="7" x="3" y="14" rx="1"/>',
+  "sliders": '<line x1="4" x2="4" y1="21" y2="14"/><line x1="4" x2="4" y1="10" y2="3"/><line x1="12" x2="12" y1="21" y2="12"/><line x1="12" x2="12" y1="8" y2="3"/><line x1="20" x2="20" y1="21" y2="16"/><line x1="20" x2="20" y1="12" y2="3"/><line x1="1" x2="7" y1="14" y2="14"/><line x1="9" x2="15" y1="8" y2="8"/><line x1="17" x2="23" y1="16" y2="16"/>',
+
+  // 判定・アラート・ヘルプ
+  "check": '<path d="M20 6 9 17l-5-5"/>',
+  "check-circle-2": '<circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/>',
+  "x-circle": '<circle cx="12" cy="12" r="10"/><path d="m15 9-6 6"/><path d="m9 9 6 6"/>',
+  "alert-circle": '<circle cx="12" cy="12" r="10"/><line x1="12" x2="12" y1="8" y2="12"/><line x1="12" x2="12.01" y1="16" y2="16"/>',
+  "info": '<circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/>',
+  "help-circle": '<circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/>',
+
+  // ファイル / アプリ / ツール
+  "folder": '<path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/>',
+  "folder-open": '<path d="m6 14 1.5-2.9A2 2 0 0 1 9.24 10H20a2 2 0 0 1 1.94 2.5l-1.54 6a2 2 0 0 1-1.95 1.5H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h3.9a2 2 0 0 1 1.69.9l.81 1.2a2 2 0 0 0 1.67.9H18a2 2 0 0 1 2 2v2"/>',
+  "file": '<path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/>',
+  "file-text": '<path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="M10 9H8"/><path d="M16 13H8"/><path d="M16 17H8"/>',
+  "edit": '<path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/>',
+  "trash-2": '<path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/><line x1="10" x2="10" y1="11" y2="17"/><line x1="14" x2="14" y1="11" y2="17"/>',
+  "plus": '<path d="M5 12h14"/><path d="M12 5v14"/>',
+  "minus-circle": '<circle cx="12" cy="12" r="10"/><path d="M8 12h8"/>',
+  "plus-circle": '<circle cx="12" cy="12" r="10"/><path d="M8 12h8"/><path d="M12 8v8"/>',
+  "calculator": '<rect width="16" height="20" x="4" y="2" rx="2"/><line x1="8" x2="16" y1="6" y2="6"/><line x1="16" x2="16" y1="14" y2="18"/><path d="M16 10h.01"/><path d="M12 10h.01"/><path d="M8 10h.01"/><path d="M12 14h.01"/><path d="M8 14h.01"/><path d="M12 18h.01"/><path d="M8 18h.01"/>',
+  "copy": '<rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/>',
+  "external-link": '<path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>',
+};
+
+/**
+ * ESKitIcons — アイコンレジストリ
+ *
+ * アイコンセット単位で SVG 定義を管理する。
+ */
+export default class ESKitIcons {
+  #sets = new Map();
+
+  constructor() {
+    // 組み込み Lucide セットを同期登録
+    this.registerSet("lucide", LUCIDE_ICONS);
+  }
+
+  /**
+   * アイコンセットを登録する。
+   * @param {string} setId - セット識別子 (例: "lucide", "custom")
+   * @param {Record<string, string>} icons - アイコン名 → 内部 SVG 文字列のマップ
+   */
+  registerSet(setId, icons) {
+    if (!setId || typeof setId !== "string") {
+      throw new TypeError("[ESKitIcons] setId must be a non-empty string");
+    }
+    if (!icons || typeof icons !== "object") {
+      throw new TypeError("[ESKitIcons] icons must be an object");
+    }
+
+    let set = this.#sets.get(setId);
+    if (!set) {
+      set = new Map();
+      this.#sets.set(setId, set);
+    }
+
+    for (const [name, svgContent] of Object.entries(icons)) {
+      set.set(name, svgContent);
+    }
+  }
+
+  /**
+   * 指定したセットとアイコン名の内部 SVG 文字列を取得する。
+   * @param {string} setId
+   * @param {string} name
+   * @returns {string | null}
+   */
+  get(setId, name) {
+    return this.#sets.get(setId)?.get(name) ?? null;
+  }
+
+  /**
+   * 指定したセット（およびアイコン名）が存在するか判定する。
+   * @param {string} setId
+   * @param {string} [name]
+   * @returns {boolean}
+   */
+  has(setId, name) {
+    const set = this.#sets.get(setId);
+    if (!set) return false;
+    if (name === undefined) return true;
+    return set.has(name);
+  }
+
+  /**
+   * 登録済みの全セット名一覧を返す。
+   * @returns {string[]}
+   */
+  listSets() {
+    return Array.from(this.#sets.keys());
+  }
+
+  /**
+   * 指定したセットの全アイコン名一覧を返す。
+   * @param {string} setId
+   * @returns {string[]}
+   */
+  listIcons(setId) {
+    const set = this.#sets.get(setId);
+    return set ? Array.from(set.keys()) : [];
+  }
+
+  /**
+   * マニフェストの icon 定義（`set` または `image`）からアイコン用 DOM 要素を生成する。
+   * @param {object | null} iconDef
+   * @param {{ size?: number | string, className?: string, alt?: string }} [options]
+   * @returns {HTMLElement}
+   */
+  createAppIcon(iconDef, options = {}) {
+    const { size, className, alt = "" } = options;
+
+    if (iconDef && typeof iconDef === "object") {
+      if (iconDef.type === "set") {
+        const el = document.createElement("eskit-icon");
+        el.setAttribute("set", iconDef.set || "lucide");
+        el.setAttribute("name", iconDef.name || "package");
+        if (size) el.setAttribute("size", String(size));
+        if (className) el.className = className;
+        return el;
+      }
+      if (iconDef.type === "image" && iconDef.src) {
+        const img = document.createElement("img");
+        img.src = iconDef.src;
+        img.alt = alt;
+        if (size) {
+          img.style.width = typeof size === "number" ? `${size}px` : size;
+          img.style.height = typeof size === "number" ? `${size}px` : size;
+        }
+        if (className) img.className = className;
+        return img;
+      }
+    }
+
+    // デフォルトフォールバック
+    const el = document.createElement("eskit-icon");
+    el.setAttribute("set", "lucide");
+    el.setAttribute("name", "package");
+    if (size) el.setAttribute("size", String(size));
+    if (className) el.className = className;
+    return el;
+  }
+}
+
+/**
+ * `<eskit-icon>` DOM 要素を生成するショートハンドヘルパー関数。
+ * Hamon テンプレートや動的 DOM 構築で利用する。
+ *
+ * @param {string} set - アイコンセット名 (例: "lucide")
+ * @param {string} name - アイコン名 (例: "search")
+ * @param {{ size?: number | string, strokeWidth?: number | string, color?: string, className?: string }} [options]
+ * @returns {HTMLElement}
+ */
+export function icon(set, name, options = {}) {
+  const el = document.createElement("eskit-icon");
+  el.setAttribute("set", set);
+  el.setAttribute("name", name);
+  if (options.size !== undefined) {
+    el.setAttribute("size", String(options.size));
+  }
+  if (options.strokeWidth !== undefined) {
+    el.setAttribute("stroke-width", String(options.strokeWidth));
+  }
+  if (options.color !== undefined) {
+    el.setAttribute("color", options.color);
+  }
+  if (options.className) {
+    el.className = options.className;
+  }
+  return el;
+}

--- a/system/manifest.js
+++ b/system/manifest.js
@@ -56,11 +56,38 @@ export default class ESKitManifest {
       console.warn(`[ESKitManifest] Unknown permissions in ${appDir}: ${unknownPerms.join(", ")}`);
     }
 
+    let normalizedIcon = null;
+    if (obj.icon !== undefined && obj.icon !== null) {
+      if (typeof obj.icon !== "object" || Array.isArray(obj.icon)) {
+        throw new Error(`[ESKitManifest] "icon" must be an object ({ type: "set" | "image", ... }) in ${appDir}`);
+      }
+      if (obj.icon.type === "set") {
+        if (!obj.icon.name || typeof obj.icon.name !== "string") {
+          throw new Error(`[ESKitManifest] icon of type "set" requires a "name" string in ${appDir}`);
+        }
+        normalizedIcon = {
+          type: "set",
+          set: typeof obj.icon.set === "string" ? obj.icon.set : "lucide",
+          name: obj.icon.name,
+        };
+      } else if (obj.icon.type === "image") {
+        if (!obj.icon.src || typeof obj.icon.src !== "string") {
+          throw new Error(`[ESKitManifest] icon of type "image" requires a "src" string in ${appDir}`);
+        }
+        normalizedIcon = {
+          type: "image",
+          src: obj.icon.src,
+        };
+      } else {
+        throw new Error(`[ESKitManifest] Invalid icon type "${obj.icon.type}" (expected "set" or "image") in ${appDir}`);
+      }
+    }
+
     return {
       id:          String(obj.id),
       name:        String(obj.name),
       entry:       String(obj.entry),
-      icon:        obj.icon  ? String(obj.icon)  : null,
+      icon:        normalizedIcon,
       version:     obj.version     ? String(obj.version)     : "0.0.1",
       description: obj.description ? String(obj.description) : "",
       permissions,

--- a/system/system.js
+++ b/system/system.js
@@ -5,7 +5,13 @@ import ESKitRegistry    from "./registry.js";
 import ESKitPermissions from "./permissions.js";
 import ESKitShellMode   from "./shell-mode.js";
 import ESKitUsers       from "./users.js";
+import ESKitIcons       from "./icons.js";
 import ESKitLoginScreenElement from "./elements/login-screen/main.js";
+import ESKitIconElement        from "./elements/icon/main.js";
+
+if (!customElements.get("eskit-icon")) {
+  customElements.define("eskit-icon", ESKitIconElement);
+}
 
 if (!customElements.get("eskit-login-screen")) {
   customElements.define("eskit-login-screen", ESKitLoginScreenElement);
@@ -30,6 +36,7 @@ export default class ESKitSystem {
   permissions = new ESKitPermissions();
   shellMode   = new ESKitShellMode();
   users       = new ESKitUsers();
+  icons       = new ESKitIcons();
 
   constructor() {
     window.System      = this;
@@ -164,24 +171,24 @@ export default class ESKitSystem {
       cm.show(e.clientX, e.clientY, [
         this.shellMode.isMobile
           ? {
-              icon: "💠",
+              icon: { set: "lucide", name: "monitor-smartphone" },
               label: "ドロワーを開く",
               action: () => this.WindowSystem?.drawer?.toggle(),
             }
           : {
-              icon: "💠",
+              icon: { set: "lucide", name: "boxes" },
               label: "ランチャーを開く",
               action: () => this.events.emit("launcher:toggle"),
             },
         { separator: true },
         {
-          icon: "🔍",
+          icon: { set: "lucide", name: "search" },
           label: "検索",
           action: () => this.WindowSystem?.beacon?.toggle(),
         },
         { separator: true },
         {
-          icon: "🔄",
+          icon: { set: "lucide", name: "refresh-cw" },
           label: `${this.shellMode.isMobile ? "Desktop" : "Mobile"} モードに切替`,
           action: () => this.setShellMode(this.shellMode.isMobile ? "desktop" : "mobile"),
         },
@@ -235,7 +242,7 @@ export default class ESKitSystem {
     app._windowElement  = windowElement;
 
     app.initialize();
-    this.events.emit("app:opened", { uuid, name: app.name });
+    this.events.emit("app:opened", { uuid, name: app.name, icon: app._manifest?.icon ?? null });
 
     return uuid;
   }
@@ -281,6 +288,7 @@ export default class ESKitSystem {
     return [...this.#process.entries()].map(([uuid, app]) => ({
       uuid,
       name:  app.name,
+      icon:  app._manifest?.icon ?? null,
       state: app._state,
     }));
   }

--- a/system/window.js
+++ b/system/window.js
@@ -123,7 +123,8 @@ export default class ESKitWindowSystem {
 
     const shadowRoot = appElement.shadowRoot;
 
-    // タイトル
+    // アプリアイコン & タイトル
+    appElement.setIcon(appInstance.manifest?.icon);
     shadowRoot.querySelector(".app-title").textContent = appInstance.name;
 
     // 閉じるボタン


### PR DESCRIPTION
## Summary
Phase 4.8「Icon System（Lucide Icons）」を導入し、OS シェル全体および標準アプリのアイコン表示を統一・刷新しました。

### 主な変更点

1. **Icon System & Web Component の新設**
   - `ESKitIcons` レジストリ（`system/icons.js`）の実装（Lucide アイコン 56 種をバンドル）
   - `<eskit-icon>` Web Component（`system/elements/icon/`）の実装（`set`, `name`, `size`, `color`, `stroke-width` にリアクティブ対応）
   - `System.icons.createAppIcon()` によるアプリアイコン生成の共通化
   - ヘルパー関数 `icon(set, name, options)` の提供

2. **OS シェルおよびアプリ UI のアイコン刷新**
   - **ウィンドウ (`eskit-window`)**: タイトルバー左端のアプリアイコン表示、コントロールボタン（最小化・最大化・閉じる）の SVG 化
   - **タスクバー & ランチャー**: ランチャーボタン（`boxes`）、タスクバー上の各アプリアイコン
   - **ドロワー (`eskit-drawer`)**: 上部設定/検索ボタン、実行中アプリアイコン、全アプリアイコン
   - **クイック設定 (`eskit-quick-settings`)**: 各設定項目アイコンの適用、ダークモード時の文字色修正、Flexbox 垂直中央揃え
   - **権限ダイアログ (`eskit-permission-dialog`)**: タイトルへの `shield` アイコン配置
   - **ログイン画面 (`eskit-login-screen`)**: ユーザー・パスワードラベル、ログイン送信ボタン
   - **ビーコン & コンテキストメニュー**: 検索・操作項目のアイコン化

3. **セキュリティ & バリデーション**
   - `define.json` の `icon` 定義バリデーションの厳格化（`{ type: "set" }` / `{ type: "image" }`）
   - `ESKitApp.prototype.manifest` のイミュータブル（`Object.freeze`）化による改ざん防止
   - `System.listProcesses()` および `app:opened` イベントペイロードへの `icon` 追加

4. **サードパーティライセンス表記 & ドキュメント**
   - `THIRD_PARTY_LICENSES.md` の新設（Lucide Icons / ISC License）
   - `API.md` に `System.icons`, `<eskit-icon>`, `ESKitApp.prototype.manifest` リファレンスを追加
   - `PLAN.md` の Phase 4.8 を完了に更新

5. **自動テスト**
   - `apps/test/`（System Verifier）に「Icon System」テストスイート（5 項目）を追加

### 検証結果
- `scratch/test_icons.mjs` による単体テスト: 全テスト PASS (56 アイコン登録、バリデーション、不変性)
- System Verifier (Web UI) によるブラウザ統合テスト: PASS
